### PR TITLE
fix a validation error for a valid case according to RAML spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "data2code": "0.0.7",
     "gulp-util": "3.0.1",
-    "raml-parser": "0.8.7",
+    "raml-parser": "0.8.10",
     "through2": "0.6.3"
   },
   "devDependencies": {


### PR DESCRIPTION
I'm using raml2code with a RAML file that contains 'displayName' properties in the method definitions.  This causes a validation error due to a bug in raml-js-parser (https://github.com/raml-org/raml-js-parser/issues/108).  This bugfix is in later versions of the parser and would probably be of interest to anyone using raml2code.
